### PR TITLE
Fix crash with Table adapter endDisplay closure.

### DIFF
--- a/Sources/FlowKit/Table/TableAdapter.swift
+++ b/Sources/FlowKit/Table/TableAdapter.swift
@@ -168,7 +168,8 @@ open class TableAdapter<M: ModelProtocol, C: CellProtocol>: TableAdapterProtocol
 			
 		case .endDisplay:
 			guard let callback = self.on.endDisplay else { return nil }
-			callback((context.cell as! C), context.path!)
+      guard let cell = context.cell as? C, let path = context.path else { return nil }
+      callback(cell, path)
 			
 		case .shouldShowMenu:
 			guard let callback = self.on.shouldShowMenu else { return nil }


### PR DESCRIPTION
I faced a crash when subscribe on endDisplay event for TableAdapter.
The problem was notification of all director's adapters about the end of displaying concrete cell a and with the cell force cast in adapters func dispatch(_ event: TableAdapterEventsKey, context: InternalContext) -> Any?.
I provided the workaround to avoid crash, but I think the best solution is to notify only that adapter, which responsible for displaying dissapeared cell.