### PR TITLE
Fix endDisplay event crash for collection directors with multiple adapters

### DIFF
--- a/Sources/FlowKit/Collection/CollectionDirector.swift
+++ b/Sources/FlowKit/Collection/CollectionDirector.swift
@@ -397,9 +397,8 @@ public extension CollectionDirector {
 	}
 	
 	func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-		self.adapters.forEach {
-			($0.value as! AbstractAdapterProtocolFunctions).dispatch(.endDisplay, context: InternalContext.init(nil, indexPath, cell, collectionView))
-		}
+        let (_,adapter) = self.context(forItemAt: indexPath)
+        adapter.dispatch(.endDisplay, context: InternalContext.init(nil, indexPath, cell, collectionView))
 	}
 
 	


### PR DESCRIPTION
Bug: 
Using the endDisplay callback on a collection director that contains multiple adapters of different cell types causes a crash. This crash is due to all adapters being dispatched the endDisplay event, where the correct behavior would be to only dispatch to the relevant adapter.

Fix: Make endDisplay logic match other dispatch events, calling only the relevant adapter.