### PR TITLE
Fix dequeue not calling for UICollectionReusableView

### DIFF
--- a/ExampleApp/Collection Example/CollectionExampleController.swift
+++ b/ExampleApp/Collection Example/CollectionExampleController.swift
@@ -80,6 +80,9 @@ class CollectionExampleController: UIViewController {
 		header.on.referenceSize = { _ in
 			return CGSize(width: self.collectionView!.frame.width, height: 40)
 		}
+        header.on.dequeue = { ctx in
+            ctx.view?.label?.text = "Header Title"
+        }
 		let section = CollectionSection.init(list, headerView: header)
 		
 		self.director?.add(section)

--- a/Sources/FlowKit/Collection/CollectionDirector.swift
+++ b/Sources/FlowKit/Collection/CollectionDirector.swift
@@ -531,7 +531,8 @@ public extension CollectionDirector {
 	}
 	
 	public func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath) {
-		
+
+        guard indexPath.section < sections.count else { return }
 		switch elementKind {
         case UICollectionView.elementKindSectionHeader:
 			let header = (sections[indexPath.section].header as? AbstractCollectionHeaderFooterItem)
@@ -548,7 +549,8 @@ public extension CollectionDirector {
 	}
 	
 	public func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath) {
-		
+
+        guard indexPath.section < sections.count else { return }
 		switch elementKind {
         case UICollectionView.elementKindSectionHeader:
 			let header = (sections[indexPath.section].header as? AbstractCollectionHeaderFooterItem)

--- a/Sources/FlowKit/Collection/CollectionDirector.swift
+++ b/Sources/FlowKit/Collection/CollectionDirector.swift
@@ -517,7 +517,16 @@ public extension CollectionDirector {
 		}
 		
 		let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: identifier, for: indexPath)
-	
+
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            _ = (section.header as? AbstractCollectionHeaderFooterItem)?.dispatch(.dequeue, type: .header, view: view, section: indexPath.section, collection: collectionView)
+        case UICollectionView.elementKindSectionFooter:
+            _ = (section.header as? AbstractCollectionHeaderFooterItem)?.dispatch(.dequeue, type: .footer, view: view, section: indexPath.section, collection: collectionView)
+        default:
+            break
+        }
+
 		return view
 	}
 	


### PR DESCRIPTION
Declaring `CollectionHeaderView<x>.on.dequeue` doesn't get called inside any code of a framework.
Easily can be tested with adding `on.dequeue` in ExampleApp `CollectionExampleController.swift`.

This pull requests fixes this issue. Probably this is not the proper way to get dispatcher. Correct me if I'm wrong.
But that needs to be fixed asap